### PR TITLE
chore: bump Go version to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/jackchuka/protoc-gen-connect-go-handler
 
-go 1.24
+go 1.26.1
 
 require google.golang.org/protobuf v1.36.11


### PR DESCRIPTION
## Summary
- Bump Go version from 1.24 to 1.26.1
- Includes security fixes (crypto/x509, html/template, net/url, os)
- Green Tea GC enabled by default for improved performance

## Test plan
- [x] `go mod tidy` succeeded
- [x] `go test ./...` passed locally